### PR TITLE
api router

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -1,18 +1,22 @@
 package router
 
 import (
+	"path"
+
 	"github.com/chord-dht/chord-backend/handlers"
 
 	"github.com/gin-gonic/gin"
 )
 
-func SetupRouter(r *gin.Engine) {
-	r.GET("/nodestatus", handlers.NodeStatus)
-	r.POST("/new", handlers.CreateNode)
-	r.GET("/initialize", handlers.InitializeNode)
-	r.GET("/quit", handlers.QuitNode)
-	r.GET("/printstate", handlers.GetNodeState)
-	r.POST("/storefile", handlers.StoreFile)
-	r.POST("/getfile", handlers.GetFile)
-	r.POST("/downloadfile", handlers.DownloadFile)
+func SetupAPIRouter(prefixPath string, r *gin.Engine) {
+	basePath := "/" + prefixPath
+
+	r.GET(path.Join(basePath, "nodestatus"), handlers.NodeStatus)
+	r.POST(path.Join(basePath, "new"), handlers.CreateNode)
+	r.GET(path.Join(basePath, "initialize"), handlers.InitializeNode)
+	r.GET(path.Join(basePath, "quit"), handlers.QuitNode)
+	r.GET(path.Join(basePath, "printstate"), handlers.GetNodeState)
+	r.POST(path.Join(basePath, "storefile"), handlers.StoreFile)
+	r.POST(path.Join(basePath, "getfile"), handlers.GetFile)
+	r.POST(path.Join(basePath, "downloadfile"), handlers.DownloadFile)
 }


### PR DESCRIPTION
This pull request includes changes to the `router/router.go` file to enhance the flexibility of the API routing by allowing a customizable prefix path for all routes.

Enhancements to API routing:

* Modified the `SetupRouter` function to `SetupAPIRouter` to include a `prefixPath` parameter, enabling the configuration of a base path for all routes.
* Updated the route definitions to use the `path.Join` function for appending the `basePath` to each route, ensuring that the routes are correctly prefixed.